### PR TITLE
Fix IF statement

### DIFF
--- a/smartbrute.py
+++ b/smartbrute.py
@@ -1711,7 +1711,7 @@ def get_options():
         exit(0)
 
     if options.bruteforced_protocol == "kerberos":
-        if options.bf_hash is not None or options.bf_hashes_file is not None and options.etype != "rc4":
+        if (options.bf_hash is not None or options.bf_hashes_file is not None) and options.etype != "rc4":
             print("error: -e/--etype was set to aes128 or aes256 but a RC4 key (or set of) was supplied with -bh/-bH, this doesn't make sense. Resuming the bruteforce with RC4 etype.")
             kerberos_parser.print_help()
             exit(0)


### PR DESCRIPTION
(`A` **or** `B` **and** `C`) is (`A` **or** (`B` **and** `C`)) but not ((`A` **or** `B`) **and** `C`) (as it should be here (⌒ω⌒))
Just kidding - a fix for IF statement in this PR.