### PR TITLE
Improvements and bugfixes for Kerberos-only environments

### DIFF
--- a/smartbrute.py
+++ b/smartbrute.py
@@ -997,7 +997,11 @@ class bruteforce(object):
                 except ldap3.core.exceptions.LDAPSocketOpenError:
                     ldap_connection = self.kerberos.LDAP_authentication(kdc_ip=self.options.auth_kdc_ip, tls_version=ssl.PROTOCOL_TLSv1, domain=self.options.auth_domain, user=self.options.auth_user, password=self.options.auth_password, rc4_key=self.options.auth_rc4_key, aes_key=self.options.auth_aes_key, ccache_ticket=self.options.auth_ccache_ticket, kdc_host=self.options.kdc_host)
             else:
-                ldap_connection = self.kerberos.LDAP_authentication(kdc_ip=self.options.auth_kdc_ip, tls_version=None, domain=self.options.auth_domain, user=self.options.auth_user, password=self.options.auth_password, rc4_key=self.options.auth_rc4_key, aes_key=self.options.auth_aes_key, ccache_ticket=self.options.auth_ccache_ticket, kdc_host=self.options.kdc_host)
+                try:
+                    ldap_connection = self.kerberos.LDAP_authentication(kdc_ip=self.options.auth_kdc_ip, tls_version=None, domain=self.options.auth_domain, user=self.options.auth_user, password=self.options.auth_password, rc4_key=self.options.auth_rc4_key, aes_key=self.options.auth_aes_key, ccache_ticket=self.options.auth_ccache_ticket, kdc_host=self.options.kdc_host)
+                except ldap.LDAPSessionError as e:
+                    if "strongerAuthRequired" in str(e) or "TLS" in str(e):
+                        raise Exception("LDAP authentication failed:\n%s.\nTry using the --use-ldaps option." % str(e))
             if ldap_connection:
                 logger.success("Successfully logged in, fetching domain information")
                 if self.options.enum_users:

--- a/smartbrute.py
+++ b/smartbrute.py
@@ -924,12 +924,12 @@ class bruteforce(object):
             elif user in self.special_users:
                 printed_details.append("[bold blue]special account[/bold blue]")
             if details == "KRB_ERR_RESPONSE_TOO_BIG":
-                logger.verbose("Raised KRB_ERR_RESPONSE_TOO_BIG for domain (%s), user (%s) and password (%s), auth is prbbly ok, set --transport-protocol to tcp to make sure of it" % (self.options.domain, user, password))
+                logger.verbose("Raised KRB_ERR_RESPONSE_TOO_BIG for domain (%s), user (%s) and password (%s), auth is prbbly ok, set --transport-protocol to tcp to make sure of it" % (domain, user, password))
                 printed_details.append("[yellow3](probably valid)[/yellow3]")
                 style = "green"
                 self.table.add_row(domain, user, secret, " ".join(printed_details), style=style)
             if details == "KRB_AP_ERR_SKEW":
-                logger.verbose("Raised KRB_AP_ERR_SKEW for domain (%s), user (%s) and password (%s), auth is prbbly ok, but there is a time skew between the machines" % (self.options.domain, user, password))
+                logger.verbose("Raised KRB_AP_ERR_SKEW for domain (%s), user (%s) and password (%s), auth is prbbly ok, but there is a time skew between the machines" % (domain, user, password))
                 logger.verbose("Server time is %s (UTC)" % self.kerberos.server_time)
                 printed_details.append("[yellow3](probably valid)[/yellow3]")
                 style = "green"


### PR DESCRIPTION
When using smartbrute with Kerberos authentication, smartbrute tries to look up the KDC hostname (`get_machine_name()`), which it requires to construct the SPN, via SMB anonymous login. This leads to an unhandled exception in environments where NTLM authentication is disabled. I added a command line argument `--dc-host` to specify the KDC host directly, eliminating the lookup via SMB. This is similar to [the approach taken in some impacket example scripts](https://github.com/SecureAuthCorp/impacket/pull/1363).

While I was at it, I also fixed a small bug and added a hint to use `--use-ldaps` when Kerberos login over plain LDAP fails.