### PR TITLE
Fix missing maxi variable

### DIFF
--- a/smartbrute.py
+++ b/smartbrute.py
@@ -1172,6 +1172,7 @@ class bruteforce(object):
                     logger.error("Mismatch between the number of users (%d) and the number of passwords (%d), can't try line per line, exiting..." % (len(users), len(passwords)))
                     exit(0)
                 else:
+                    maxi = len(users)
                     for i in range(len(users)):
                         self.table.caption = "  [yellow3]User[/]: %d/%d (%3.1f%%) (%s)" % (i, maxi, round(i/maxi*100,1), users[i].rstrip())
                         success = self.bruteforce_try_password_or_hash(user=users[i], password=passwords[i], password_hash=None)


### PR DESCRIPTION
Fix of the following traceback:
```
Traceback (most recent call last):
  File "/root/.local/bin/smartbrute", line 1866, in <module>
    main(options, logger, console, neo4j)
  File "/root/.local/bin/smartbrute", line 1842, in main
    bf.bruteforce_attack()
  File "/root/.local/bin/smartbrute", line 1176, in bruteforce_attack
    self.table.caption = "  [yellow3]User[/]: %d/%d (%3.1f%%) (%s)" % (i, maxi, round(i/maxi*100,1), users[i].rstrip())
                                                                          ^^^^
UnboundLocalError: cannot access local variable 'maxi' where it is not associated with a value
```